### PR TITLE
Add start button and timer name label

### DIFF
--- a/src/main/java/bc/bob/amnesia/Main.java
+++ b/src/main/java/bc/bob/amnesia/Main.java
@@ -137,7 +137,8 @@ public class Main extends javax.swing.JFrame {
         final int hours = Integer.parseInt(this.jTextFieldTimerHours.getText());
         final int minutes = Integer.parseInt(this.jTextFieldTimerMinutes.getText());
         final TimerModel model = new TimerModel(hours, minutes);
-        final TimerPanel panel = new TimerPanel(model, this.jPanelTimers);
+        final String name = this.jTextFieldTimerName.getText();
+        final TimerPanel panel = new TimerPanel(model, this.jPanelTimers, name);
         this.jPanelTimers.add(panel);
         this.jPanelTimers.revalidate();
     }

--- a/src/main/java/bc/bob/amnesia/TimerPanel.java
+++ b/src/main/java/bc/bob/amnesia/TimerPanel.java
@@ -14,32 +14,41 @@ import java.util.Objects;
 public final class TimerPanel extends JPanel {
 
     private final TimerModel model;
+    private final JLabel labelName;
     private final JLabel labelHours;
     private final JLabel labelMinutes;
     private final JLabel labelSeconds;
     private final JButton buttonDelete;
     private final JButton buttonReset;
     private final JButton buttonStop;
+    private final JButton buttonStart;
     private final Timer uiTimer;
     private final JPanel container;
 
-    public TimerPanel(final TimerModel model, final JPanel container) {
+    public TimerPanel(final TimerModel model, final JPanel container, final String name) {
         super();
         this.model = Objects.requireNonNull(model, "model");
         this.container = Objects.requireNonNull(container, "container");
+        final String timerName = Objects.requireNonNull(name, "name");
+        this.labelName = new JLabel(timerName);
         this.labelHours = new JLabel("0");
         this.labelMinutes = new JLabel("0");
         this.labelSeconds = new JLabel("0");
         this.buttonDelete = new JButton("Delete");
         this.buttonReset = new JButton("Reset");
         this.buttonStop = new JButton("Stop");
+        this.buttonStart = new JButton("Start");
         setLayout(new java.awt.FlowLayout());
+        if (!timerName.isEmpty()) {
+            add(this.labelName);
+        }
         add(this.labelHours);
         add(this.labelMinutes);
         add(this.labelSeconds);
         add(this.buttonDelete);
         add(this.buttonReset);
         add(this.buttonStop);
+        add(this.buttonStart);
         updateLabels();
         this.uiTimer = new Timer(1000, new ActionListener() {
             public void actionPerformed(final ActionEvent e) {
@@ -66,6 +75,12 @@ public final class TimerPanel extends JPanel {
             public void actionPerformed(final ActionEvent e) {
                 TimerPanel.this.model.stop();
                 TimerPanel.this.uiTimer.stop();
+            }
+        });
+        this.buttonStart.addActionListener(new ActionListener() {
+            public void actionPerformed(final ActionEvent e) {
+                TimerPanel.this.model.start();
+                TimerPanel.this.uiTimer.start();
             }
         });
     }

--- a/src/test/java/bc/bob/amnesia/TimerPanelTest.java
+++ b/src/test/java/bc/bob/amnesia/TimerPanelTest.java
@@ -1,0 +1,73 @@
+package bc.bob.amnesia;
+
+import java.lang.reflect.Field;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.Timer;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link TimerPanel}.
+ */
+public class TimerPanelTest {
+
+    @Test
+    public void startButtonRestartsTimer() throws Exception {
+        // Initialization.
+        final TimerModel model = new TimerModel(0, 1);
+        final JPanel container = new JPanel();
+        final TimerPanel panel = new TimerPanel(model, container, "");
+        final Field uiTimerField = TimerPanel.class.getDeclaredField("uiTimer");
+        uiTimerField.setAccessible(true);
+        final Timer timer = (Timer) uiTimerField.get(panel);
+        timer.stop();
+        final Field stopField = TimerPanel.class.getDeclaredField("buttonStop");
+        stopField.setAccessible(true);
+        final JButton buttonStop = (JButton) stopField.get(panel);
+        final Field startField = TimerPanel.class.getDeclaredField("buttonStart");
+        startField.setAccessible(true);
+        final JButton buttonStart = (JButton) startField.get(panel);
+
+        // Execution.
+        buttonStop.doClick();
+        model.tick();
+        buttonStart.doClick();
+        model.tick();
+
+        // Assertion.
+        assertThat(model.getMinutes(), is(0));
+        assertThat(model.getSeconds(), is(59));
+    }
+
+    @Test
+    public void showsNameLabelWhenNameProvided() throws Exception {
+        // Initialization.
+        final String name = "Test";
+        final TimerModel model = new TimerModel(0, 1);
+        final JPanel container = new JPanel();
+        final TimerPanel panel = new TimerPanel(model, container, name);
+        final Field uiTimerField = TimerPanel.class.getDeclaredField("uiTimer");
+        uiTimerField.setAccessible(true);
+        final Timer timer = (Timer) uiTimerField.get(panel);
+        timer.stop();
+        final java.awt.Component[] components = panel.getComponents();
+        boolean found = false;
+
+        // Execution.
+        for (int i = 0; i < components.length; i += 1) {
+            final java.awt.Component comp = components[i];
+            if (comp instanceof JLabel) {
+                final JLabel label = (JLabel) comp;
+                if (name.equals(label.getText())) {
+                    found = true;
+                }
+            }
+        }
+
+        // Assertion.
+        assertThat(found, is(true));
+    }
+}


### PR DESCRIPTION
## Summary
- allow optional timer names to display with each created timer
- add a Start button so stopped timers can resume
- cover timer panel behavior with unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_b_68c73251bd98832b9ed3179285045be0